### PR TITLE
Fix link for WebTest documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -307,5 +307,5 @@ API related to Flask-SQLAlchemy
 
    .. automethod:: pop
 
-.. _WebTest: http://webtest.readthedocs.org/en/
+.. _WebTest: http://webtest.readthedocs.org/
 .. _Flask: http://flask.pocoo.org/


### PR DESCRIPTION
The link for WebTest documentation in flask-webtest documentation is wrong
